### PR TITLE
Added framework matplotlib classifier to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
     install_requires=['matplotlib'],
 
     classifiers=[
+        'Framework :: Matplotlib', 
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 3',
     ],


### PR DESCRIPTION
As described in matplotlib/matplotlib#16592, matplotlib now has a PyPI classifier & adding it to your setup.py will let folks browsing on PyPI know that your package is part of the Matplotlib ecosystem.