### PR TITLE
Add option to make specific lines glow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-- 3.7
+- 3.8
 install:
 - python setup.py install
 - pip install -r tests/test-requirements.txt

--- a/mplcyberpunk/core.py
+++ b/mplcyberpunk/core.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 
-from typing import Optional
+from typing import Optional, Union, List
 
+from matplotlib.lines import Line2D
 import matplotlib.pyplot as plt
 
 
@@ -16,6 +17,7 @@ def make_lines_glow(
     n_glow_lines: int = 10,
     diff_linewidth: float = 1.05,
     alpha_line: float = 0.3,
+    lines: Union[Line2D, List[Line2D]] = None,
 ) -> None:
     """Add a glow effect to the lines in an axis object.
 
@@ -24,7 +26,8 @@ def make_lines_glow(
     if not ax:
         ax = plt.gca()
 
-    lines = ax.get_lines()
+    lines = ax.get_lines() if lines is None else lines
+    lines = [lines] if isinstance(lines, Line2D) else lines
 
     alpha_value = alpha_line / n_glow_lines
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,6 +1,5 @@
 # Sample Test passing with and pytest
 
-from unittest import expectedFailure
 import pandas as pd
 import matplotlib.pyplot as plt
 import mplcyberpunk

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,10 +1,10 @@
 # Sample Test passing with and pytest
 
+from unittest import expectedFailure
 import pandas as pd
 import matplotlib.pyplot as plt
 import mplcyberpunk
 import random
-
 
 def test_plotting_working():
     plt.style.use("cyberpunk")
@@ -66,6 +66,29 @@ def test_linestyle_attributes_copied():
         assert line.get_marker() == marker
         assert line.get_linestyle() == linestyle
 
+
+def test_make_specific_line_glow():
+    
+    plt.style.use("cyberpunk")
+
+    values = {c: [random.randint(0, 10) for _ in range(7)] for c in 'ABCDEFG'}
+    df = pd.DataFrame(values)
+
+    marker = 'x'
+    linestyle='--'
+    df.plot(marker=marker, linestyle=linestyle)
+
+    lines = plt.gca().lines[::2]
+    mplcyberpunk.make_lines_glow(lines=lines)
+
+    # check number of lines
+    n_original_lines = 7
+    n_glowing_original_lines = 4
+    n_lines_per_glow = 10
+    expected_num_total_lines = n_original_lines + n_glowing_original_lines * n_lines_per_glow
+    
+    new_lines = plt.gca().lines
+    assert len(new_lines) == expected_num_total_lines
 
 
 def test_axis_limits_unchanged_by_underglow():


### PR DESCRIPTION
Hi, thanks for creating mplcyberpunk! It's a very nice looking mpl style. I would like to use it in an application I'm creating where I'd like to allow a user to click on a single line to make it glow.

Changes made:
* added an optional `lines` keyword to `make_lines_glow`, which can be either a single `Line2D` or a list of `Line2D`s.
* added a test (`test_make_specific_line_glow`) to check that 4 selected lines from a total of 7 are made to glow

In my application, when a user clicks on a line that line will glow and the previously glowing line would return to normal. For this, it would be super useful if `make_specific_line_glow` could also remove the glow lines of all lines not passed to `make_lines_glow`. But I'm happy to handle this before calling `make_lines_glow` unless you think it's necessary or particularly useful to add here?