### PR TITLE
New function to create gradient-filled bar plots

### DIFF
--- a/mplcyberpunk/__init__.py
+++ b/mplcyberpunk/__init__.py
@@ -3,7 +3,7 @@
 import matplotlib as mpl
 import pkg_resources
 
-from .core import add_glow_effects, make_lines_glow, add_underglow, make_scatter_glow, add_gradient_fill
+from .core import add_glow_effects, make_lines_glow, add_underglow, make_scatter_glow, add_gradient_fill, add_bar_gradient
 
 __version__ = pkg_resources.require("mplcyberpunk")[0].version
 __author__ = 'Dominik Haitz <dominik.haitz@gmx.de>'

--- a/mplcyberpunk/core.py
+++ b/mplcyberpunk/core.py
@@ -2,11 +2,13 @@
 
 from typing import Optional, Union, List, Tuple
 import numpy as np
+import matplotlib as mpl
 from matplotlib.path import Path
 from matplotlib.lines import Line2D
 import matplotlib.pyplot as plt
 import matplotlib.colors as mcolors
 from matplotlib.patches import Polygon
+
 
 def add_glow_effects(ax: Optional[plt.Axes] = None, gradient_fill: bool = False) -> None:
     """Add a glow effect to the lines in an axis object and an 'underglow' effect below the line."""
@@ -225,3 +227,38 @@ def make_scatter_glow(
 
     for i in range(1, n_glow_lines):
         plt.scatter(x, y, s=dot_size*(diff_dotwidth**i), c=dot_color, alpha=alpha)
+
+
+def add_bar_gradient(
+    bars: mpl.container.BarContainer,
+    ax: Optional[plt.Axes] = None
+) -> None:
+    """Replace each bar with a rectangle filled with a color gradient going transparent"""
+
+    if not ax:
+        ax = plt.gca()
+
+    # freeze axis limits before calling imshow
+    ax.axis()
+    ax.autoscale(False)
+
+    for bar in bars:
+
+        # get properties of existing bar
+        x, y = bar.get_xy()
+        width, height = bar.get_width(), bar.get_height()
+        zorder = bar.zorder
+        color = bar.get_facecolor()
+
+        cmap = mcolors.LinearSegmentedColormap.from_list('gradient_cmap', [(color[0], color[1], color[2], 0), color])
+
+        ax.imshow(
+            X=[[1, 1],[0, 0]],  # pseudo-image
+            extent=[x, x+width, y, y+height],
+            cmap=cmap,
+            zorder=zorder,
+            interpolation='bicubic',
+            aspect='auto',  # to prevent mpl from auto-scaling axes equally
+        )
+
+        bar.remove()

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -168,3 +168,18 @@ def test_gradient_step():
 
     fig.set_size_inches(8, 5)
     fig.savefig("test_gradient_step.png")
+
+
+def test_gradient_bars():
+    plt.style.use('cyberpunk')
+    fig, ax = plt.subplots()
+
+    categories = ['A', 'B', 'C', 'D', 'E']
+    values = [25, 67, 19, 45, 10]
+    colors = ["C0", "C1", "C2", "C3", "C4"]
+
+    bars = ax.bar(categories, values, color=colors, zorder=2)
+
+    mplcyberpunk.add_bar_gradient(bars=bars, ax=ax)
+
+    fig.savefig('test_gradient_bars.png')


### PR DESCRIPTION
Should work like this:
```python
import matplotlib.pyplot as plt
import mplcyberpunk

plt.style.use('cyberpunk')

categories = ['A', 'B', 'C', 'D', 'E']
values = [25, 67, 19, 45, 10]
colors = ["C0", "C1", "C2", "C3", "C4"]

bars = plt.bar(categories, values, color=colors, zorder=2)

mplcyberpunk.add_bar_gradient(bars=bars)

plt.show()
```
![Unknown](https://user-images.githubusercontent.com/5802753/235376084-05842085-ea1d-4c81-aefc-2f9faed612f1.png)