### PR TITLE
remove pkg_resources

### DIFF
--- a/mplcyberpunk/__init__.py
+++ b/mplcyberpunk/__init__.py
@@ -1,15 +1,17 @@
 """mplcyberpunk - A new Python package"""
 
+import os
 import matplotlib as mpl
-import pkg_resources
+import importlib.metadata
 
 from .core import add_glow_effects, make_lines_glow, add_underglow, make_scatter_glow, add_gradient_fill, add_bar_gradient
 
-__version__ = pkg_resources.require("mplcyberpunk")[0].version
+__version__ = importlib.metadata.version("mplcyberpunk")
 __author__ = 'Dominik Haitz <dominik.haitz@gmx.de>'
 __all__ = []
 
 # register the included stylesheet in the mpl style library
-data_path = pkg_resources.resource_filename('mplcyberpunk', 'data/')
+
+data_path = os.path.join(os.path.dirname(__file__), 'data/')
 cyberpunk_stylesheets = mpl.style.core.read_style_directory(data_path)
 mpl.style.core.update_nested_dict(mpl.style.library, cyberpunk_stylesheets)


### PR DESCRIPTION
Newer versions of Python don't come with `pkg_resources`, so let's not use it! 😄 