### PR TITLE
Fixed axes assignment within make_scatter_glow

### DIFF
--- a/src/mplcyberpunk/core.py
+++ b/src/mplcyberpunk/core.py
@@ -239,7 +239,7 @@ def make_scatter_glow(
     alpha = alpha / n_glow_lines
 
     for i in range(1, n_glow_lines):
-        plt.scatter(x, y, s=dot_size * (diff_dotwidth**i), c=dot_color, alpha=alpha)
+        ax.scatter(x, y, s=dot_size * (diff_dotwidth**i), c=dot_color, alpha=alpha)
 
 
 def add_bar_gradient(


### PR DESCRIPTION
By this fix, the make_scatter_glow function creates a scatter for a specific axis if given, as all other functions in core.py. Currently, plt.scatter automatically chooses the last axis if subplots are used.